### PR TITLE
Removed LeftQuaternion

### DIFF
--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -37,63 +37,6 @@ impl<T> AsRef<[T; 4]> for Quaternion<T> {
     fn as_ref(&self) -> &[T; 4] { unsafe { ::std::mem::transmute(self) } }
 }
 
-/// Standard quaternion corresponding to a left-handed
-/// rotation matrix. The exact association of the left-handed basis
-/// that is encoded by this quaternion and a right-handed one
-/// is presented by `B` (for "basis") generic parameter.
-///
-/// Read also:
-/// https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Orientation
-#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
-#[repr(C)]
-pub struct LeftQuaternion<T, B> {
-    /// Scalar part of a quaternion.
-    pub s: T,
-    /// Vector part of a quaternion.
-    pub v: Vector3<T>,
-    /// Marker for the phantom association with the right-handed basis.
-    marker: PhantomData<B>,
-}
-
-/// Basis handedness change by mirroring X axis: x',y',z' = -x,y,z
-#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
-pub enum MirrorX {}
-/// Basis handedness change by mirroring Y axis: x',y',z' = x,-y,z
-#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
-pub enum MirrorY {}
-/// Basis handedness change by mirroring Z axis: x',y',z' = x,y,-z
-#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
-pub enum MirrorZ {}
-/// Basis handedness change by swapping X and Y axis: x',y',z' = y,x,z
-#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
-pub enum SwapXY {}
-/// Basis handedness change by swapping Y and Z axis: x',y',z' = x,z,y
-#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
-pub enum SwapYZ {}
-/// Basis handedness change by swapping Z and X axis: x',y',z' = z,y,x
-#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
-pub enum SwapZX {}
-
-impl<T: Clone, B> From<[T; 4]> for LeftQuaternion<T, B> {
-    fn from(v: [T; 4]) -> Self {
-        LeftQuaternion {
-            s: v[3].clone(),
-            v: Vector3 {
-                x: v[0].clone(),
-                y: v[1].clone(),
-                z: v[2].clone(),
-            },
-            marker: PhantomData,
-        }
-    }
-}
-
-impl<T, B> Into<[T; 4]> for LeftQuaternion<T, B> {
-    fn into(self) -> [T; 4] {
-        [self.v.x, self.v.y, self.v.z, self.s]
-    }
-}
-
 
 /// Abstract set of Euler angles in 3D space. The basis of angles
 /// is defined by the generic parameter `B`.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,8 +2,8 @@ extern crate mint;
 use mint::{
     Vector2, Point2,
     Vector3, Point3,
-    Vector4, Quaternion,
-    LeftQuaternion, EulerAngles,
+    Vector4,
+    Quaternion, EulerAngles,
 };
 use mint::{
     RowMatrix2, RowMatrix2x3,
@@ -62,11 +62,6 @@ fn vector() {
 #[test]
 fn rotation() {
     transitive!(Quaternion [s=1, v=Vector3{x: 1, y: 3, z: 5}] = [i32; 4]);
-    // LeftQuaternion
-    let a1: [i32; 4] = [1, 3, 5, 7];
-    let q: LeftQuaternion<_, mint::MirrorX> = LeftQuaternion::from(a1);
-    let a2: [i32; 4] = q.into();
-    assert_eq!(a1, a2);
     // EulerAngles
     let a1: [i32; 3] = [1, 3, 5];
     let e: EulerAngles<_, mint::ExtraXYZ> = EulerAngles::from(a1);


### PR DESCRIPTION
It only makes sense for quaternions derived from texture coordinates, but those are most often just going directly to GPU anyway, there is no need for strong CPU typing. If someone requests it, we can always add them back without breaking anything.

r? @Ralith 