### PR TITLE
make from_slice() method public

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -28,7 +28,8 @@ macro_rules! vec {
         }
 
         impl<T: Clone> $name<T> {
-            pub(crate) fn from_slice(slice: &[T]) -> Self {
+            #[allow(missing_docs)]
+            pub fn from_slice(slice: &[T]) -> Self {
                 $name {
                     $(
                         $field: slice[$index].clone(),


### PR DESCRIPTION
Probably it was made hidden for a reason, but it's quite a usable method :)

My use case: transforming [f32; 4] arrays to Vector3 with ```Vector3::from_slice(&vector[0..3])```. 