### PR TITLE
Bivector and Rotor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mint"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
 	"Dzmitry Malyshau <kvarkus@gmail.com>",
 	"Ilya Bogdanov <fumlead@gmail.com>",

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use vector::Vector3;
+use vector::{Bivector, Vector3};
 
 
 /// Standard quaternion represented by the scalar and vector parts.
@@ -34,6 +34,42 @@ impl<T> Into<[T; 4]> for Quaternion<T> {
 }
 
 impl<T> AsRef<[T; 4]> for Quaternion<T> {
+    fn as_ref(&self) -> &[T; 4] { unsafe { ::std::mem::transmute(self) } }
+}
+
+
+/// A rotor in 3D space represented by a scalar and bi-vector parts.
+/// Similar to Quaternion, can equally (isomorphically) represent
+/// rotations in 3D space.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
+#[repr(C)]
+pub struct Rotor<T> {
+    /// Scalar part of a rotor.
+    pub s: T,
+    /// Vector part of a rotor.
+    pub b: Bivector<T>,
+}
+
+impl<T: Clone> From<[T; 4]> for Rotor<T> {
+    fn from(v: [T; 4]) -> Self {
+        Rotor {
+            s: v[0].clone(),
+            b: Bivector {
+                xy: v[1].clone(),
+                xz: v[2].clone(),
+                yz: v[3].clone(),
+            },
+        }
+    }
+}
+
+impl<T> Into<[T; 4]> for Rotor<T> {
+    fn into(self) -> [T; 4] {
+        [self.s, self.b.xy, self.b.xz, self.b.yz]
+    }
+}
+
+impl<T> AsRef<[T; 4]> for Rotor<T> {
     fn as_ref(&self) -> &[T; 4] { unsafe { ::std::mem::transmute(self) } }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -63,3 +63,4 @@ vec!( Point2 [x=0, y=1] = [T; 2] );
 from!( Point2 [x,y] = Vector2 );
 vec!( Point3 [x=0, y=1, z=2] = [T; 3] );
 from!( Point3 [x,y,z] = Vector3 );
+vec!( Bivector [xy=0, xz=1, yz=2] = [T; 3] );

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,9 +1,10 @@
 extern crate mint;
 use mint::{
+    Bivector,
     Vector2, Point2,
     Vector3, Point3,
     Vector4,
-    Quaternion, EulerAngles,
+    Quaternion, Rotor, EulerAngles,
 };
 use mint::{
     RowMatrix2, RowMatrix2x3,
@@ -56,6 +57,7 @@ fn vector() {
     transitive!(Vector4 [x=1, y=3, z=5, w=7] = ref [i32; 4]);
     transitive!(Point2 [x=1, y=3] = ref [i32; 2]);
     transitive!(Point3 [x=1, y=3, z=5] = ref [i32; 3]);
+    transitive!(Bivector [xy=2, xz=3, yz=5] = ref [u32; 3]);
     // Translation Vector <-> Point
     transitive!(Point2 [x=1, y=3] = Vector2<i32>);
     transitive!(Point3 [x=1, y=3, z=5] = Vector3<i32>);
@@ -64,6 +66,7 @@ fn vector() {
 #[test]
 fn rotation() {
     transitive!(Quaternion [s=1, v=Vector3{x: 1, y: 3, z: 5}] = [i32; 4]);
+    transitive!(Rotor [s=2, b=Bivector{xy: 2, xz: 4, yz: 6}] = [u32; 4]);
     // EulerAngles
     let a1: [i32; 3] = [1, 3, 5];
     let e: EulerAngles<_, mint::ExtraXYZ> = EulerAngles::from(a1);


### PR DESCRIPTION
Fixes #32 

There is a few issues I'd like us to resolve before we settle on something:
  1. **dimensionality**: does it make sense to have Bivector3 instead of Bivector here, and similarly for Rotor?
      - there is hardly any use for other dimensions, hence I think we can avoid the number suffixes
  2. **notation**: is xy/xz/yz the only used notation for bi-vectors? How should rotor fields be called? The current "s" and "b" are just random, basically.
  3. consistency with quaternions: does anything need to be done about the fact that the vector part of a quaternion has the type of `Vector3`? It isn't really a vector, much closer to bi-vector, in which case people just need to use `Rotor` anyway. Perhaps, the `Quaternion` type shouldn't be written in the vector form at all to avoid confusion.