### PR TITLE
Remove the `$index` variable from the vec! macro, and add tests for `Vector::from_slice`

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,5 +1,5 @@
 macro_rules! vec {
-    ($name:ident [ $($field:ident = $index:expr),* ] = $fixed:ty) => {
+    ($name:ident [ $($field:ident),* ] = $fixed:ty) => {
         #[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
         #[repr(C)]
         #[allow(missing_docs)] //TODO: actually have docs
@@ -30,10 +30,14 @@ macro_rules! vec {
         impl<T: Clone> $name<T> {
             #[allow(missing_docs)]
             pub fn from_slice(slice: &[T]) -> Self {
+                let mut iter = slice.iter();
                 $name {
                     $(
-                        $field: slice[$index].clone(),
-                    )*
+                        $field: iter
+                            .next()
+                            .expect(&concat!("Missing ", stringify!($field), "-axis in slice."))
+                            .clone()
+                    ),*
                 }
             }
         }
@@ -54,12 +58,12 @@ macro_rules! from {
     }
 }
 
-vec!( Vector2 [x=0, y=1] = [T; 2] );
+vec!( Vector2 [x, y] = [T; 2] );
 from!( Vector2 [x,y] = Point2 );
-vec!( Vector3 [x=0, y=1, z=2] = [T; 3] );
+vec!( Vector3 [x, y, z] = [T; 3] );
 from!( Vector3 [x,y,z] = Point3 );
-vec!( Vector4 [x=0, y=1, z=2, w=3] = [T; 4] );
-vec!( Point2 [x=0, y=1] = [T; 2] );
+vec!( Vector4 [x, y, z, w] = [T; 4] );
+vec!( Point2 [x, y] = [T; 2] );
 from!( Point2 [x,y] = Vector2 );
-vec!( Point3 [x=0, y=1, z=2] = [T; 3] );
+vec!( Point3 [x, y, z] = [T; 3] );
 from!( Point3 [x,y,z] = Vector3 );

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -188,3 +188,15 @@ fn turn() {
         [3,7,11,15],
         [4,8,12,16]]);
 }
+
+#[test]
+fn vector_from_slice_success() {
+    let v = Vector3::from_slice(&[0.0f32, 1.0, 2.0, 3.0]);
+    assert_eq!(v, Vector3 { x: 0.0, y: 1.0, z: 2.0} );
+}
+
+#[test]
+#[should_panic(expected = "Missing y-axis in slice.")]
+fn vector_from_slice_fail() {
+    let _ = Vector4::from_slice(&[0.0]);
+}


### PR DESCRIPTION
This also changes the `panic` message in `from_slice` if the slice is too short.
