### PR TITLE
impl Default for EulerAngles and Vector types

### DIFF
--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -91,6 +91,17 @@ impl<T, B> Into<[T; 3]> for EulerAngles<T, B> {
     }
 }
 
+impl<T: Default, B> Default for EulerAngles<T, B> {
+    fn default() -> Self {
+        EulerAngles {
+            a: T::default(),
+            b: T::default(),
+            c: T::default(),
+            marker: PhantomData,
+        }
+    }
+}
+
 macro_rules! reverse {
     ($from:ident -> $to:ident) => {
         impl<T> From<EulerAngles<T, $from>> for EulerAngles<T, $to> {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,6 +1,6 @@
 macro_rules! vec {
     ($name:ident [ $($field:ident = $index:expr),* ] = $fixed:ty) => {
-        #[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
+        #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord)]
         #[repr(C)]
         #[allow(missing_docs)] //TODO: actually have docs
         pub struct $name<T> {


### PR DESCRIPTION
I didn't implement Default for Quaternions because the unit quaternion has a scalar part of 1, and I didn't implement it for matrices because I couldn't create an identity matrix, and the null matrix is a surprising default in the context of computer graphics.
