### PR TITLE
Add 2x4 and 4x2 matrices

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -80,6 +80,9 @@ turn!( RowMatrix2 : Vector2[x[x,y],y[x,y]] = ColumnMatrix2 );
 /// Useful for combining rotation, scale, and translation in 2D space.
 matrix!( RowMatrix2x3 : Vector3[x[x,y,z]=0,y[x,y,z]=1] = (3, 2));
 turn!( RowMatrix2x3 : Vector3[x[x,y,z],y[x,y,z]] = ColumnMatrix2x3 );
+/// 2x4 row-major matrix.
+matrix!( RowMatrix2x4 : Vector4[x[x,y,z,w]=0,y[x,y,z,w]=1] = (4, 2));
+turn!( RowMatrix2x4 : Vector4[x[x,y,z,w],y[x,y,z,w]] = ColumnMatrix2x4 );
 /// 3x2 row-major matrix.
 /// Useful for combining rotation, scale, and translation in 2D space.
 matrix!( RowMatrix3x2 : Vector2[x[x,y]=0,y[x,y]=1,z[x,y]=2] = (2, 3));
@@ -96,6 +99,9 @@ turn!( RowMatrix3x4 : Vector4[x[x,y,z,w],y[x,y,z,w],z[x,y,z,w]] = ColumnMatrix3x
 /// Useful for combining rotation, scale, and translation in 3D space.
 matrix!( RowMatrix4x3 : Vector3[x[x,y,z]=0,y[x,y,z]=1,z[x,y,z]=2,w[x,y,z]=3] = (3, 4));
 turn!( RowMatrix4x3 : Vector3[x[x,y,z],y[x,y,z],z[x,y,z],w[x,y,z]] = ColumnMatrix4x3 );
+// 4x2 row-major matrix.
+matrix!( RowMatrix4x2 : Vector2[x[x,y]=0,y[x,y]=1,z[x,y]=2,w[x,y]=3] = (2, 4));
+turn!( RowMatrix4x2 : Vector2[x[x,y],y[x,y],z[x,y],w[x,y]] = ColumnMatrix4x2 );
 /// 4x4 row-major matrix.
 matrix!( RowMatrix4 : Vector4[x[x,y,z,w]=0,y[x,y,z,w]=1,z[x,y,z,w]=2,w[x,y,z,w]=3] = (4, 4));
 turn!( RowMatrix4 : Vector4[x[x,y,z,w],y[x,y,z,w],z[x,y,z,w],w[x,y,z,w]] = ColumnMatrix4 );
@@ -107,6 +113,9 @@ turn!( ColumnMatrix2 : Vector2[x[x,y],y[x,y]] = RowMatrix2 );
 /// Useful for combining rotation, scale, and translation in 2D space.
 matrix!( ColumnMatrix2x3 : Vector2[x[x,y]=0,y[x,y]=1,z[x,y]=2] = (2, 3));
 turn!( ColumnMatrix2x3 : Vector2[x[x,y],y[x,y],z[x,y]] = RowMatrix2x3 );
+// 2x4 column-major matrix.
+matrix!( ColumnMatrix2x4 : Vector2[x[x,y]=0,y[x,y]=1,z[x,y]=2,w[x,y]=3] = (2, 4));
+turn!( ColumnMatrix2x4 : Vector2[x[x,y],y[x,y],z[x,y],w[x,y]] = RowMatrix2x4 );
 /// 3x2 column-major matrix.
 /// Useful for combining rotation, scale, and translation in 2D space.
 matrix!( ColumnMatrix3x2 : Vector3[x[x,y,z]=0,y[x,y,z]=1] = (3, 2));
@@ -119,6 +128,9 @@ turn!( ColumnMatrix3 : Vector3[x[x,y,z],y[x,y,z],z[x,y,z]] = RowMatrix3 );
 /// Useful for combining rotation, scale, and translation in 3D space.
 matrix!( ColumnMatrix3x4 : Vector3[x[x,y,z]=0,y[x,y,z]=1,z[x,y,z]=2,w[x,y,z]=3] = (3, 4));
 turn!( ColumnMatrix3x4 : Vector3[x[x,y,z],y[x,y,z],z[x,y,z],w[x,y,z]] = RowMatrix3x4 );
+/// 4x2 column-major matrix.
+matrix!( ColumnMatrix4x2 : Vector4[x[x,y,z,w]=0,y[x,y,z,w]=1] = (4, 2));
+turn!( ColumnMatrix4x2 : Vector4[x[x,y,z,w],y[x,y,z,w]] = RowMatrix4x2 );
 /// 4x3 column-major matrix.
 /// Useful for combining rotation, scale, and translation in 3D space.
 matrix!( ColumnMatrix4x3 : Vector4[x[x,y,z,w]=0,y[x,y,z,w]=1,z[x,y,z,w]=2] = (4, 3));

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,14 +6,14 @@ use mint::{
     Quaternion, EulerAngles,
 };
 use mint::{
-    RowMatrix2, RowMatrix2x3,
+    RowMatrix2, RowMatrix2x3, RowMatrix2x4,
     RowMatrix3x2, RowMatrix3, RowMatrix3x4,
-    RowMatrix4x3, RowMatrix4,
+    RowMatrix4x2, RowMatrix4x3, RowMatrix4,
 };
 use mint::{
-    ColumnMatrix2, ColumnMatrix2x3,
+    ColumnMatrix2, ColumnMatrix2x3, ColumnMatrix2x4,
     ColumnMatrix3x2, ColumnMatrix3, ColumnMatrix3x4,
-    ColumnMatrix4x3, ColumnMatrix4,
+    ColumnMatrix4x2, ColumnMatrix4x3, ColumnMatrix4,
 };
 
 macro_rules! transitive {
@@ -81,6 +81,15 @@ fn row_matrix() {
         x=[1,2,3],
         y=[4,5,6]]
         = (3, 2): i32);
+    matrix_transitive!(RowMatrix2x4 Vector4[
+        x=[1,2,3,4],
+        y=[5,6,7,8]]
+        = (4, 2): i32);
+    matrix_transitive!(RowMatrix3x2 Vector2[
+        x=[1,2],
+        y=[3,4],
+        z=[5,6]]
+        = (2, 3): i32);
     matrix_transitive!(RowMatrix3 Vector3[
         x=[1,2,3],
         y=[4,5,6],
@@ -91,6 +100,18 @@ fn row_matrix() {
         y=[5,6,7,8],
         z=[9,10,11,12]]
         = (4, 3): i32);
+    matrix_transitive!(RowMatrix4x2 Vector2[
+        x=[1,2],
+        y=[3,4],
+        z=[5,6],
+        w=[7,8]]
+        = (2, 4): i32);
+    matrix_transitive!(RowMatrix4x3 Vector3[
+        x=[1,2,3],
+        y=[4,5,6],
+        z=[7,8,9],
+        w=[10,11,12]]
+        = (3, 4): i32);
     matrix_transitive!(RowMatrix4 Vector4[
         x=[1,2,3,4],
         y=[5,6,7,8],
@@ -110,6 +131,16 @@ fn column_matrix() {
         y=[3,4],
         z=[5,6]]
         = (2, 3): i32);
+    matrix_transitive!(ColumnMatrix2x4 Vector2[
+        x=[1,2],
+        y=[3,4],
+        z=[5,6],
+        w=[7,8]]
+        = (2, 4): i32);
+    matrix_transitive!(ColumnMatrix3x2 Vector3[
+        x=[1,2,3],
+        y=[4,5,6]]
+        = (3, 2): i32);
     matrix_transitive!(ColumnMatrix3 Vector3[
         x=[1,2,3],
         y=[4,5,6],
@@ -121,6 +152,15 @@ fn column_matrix() {
         z=[7,8,9],
         w=[10,11,12]]
         = (3, 4): i32);
+    matrix_transitive!(ColumnMatrix4x2 Vector4[
+        x=[1,2,3,4],
+        y=[5,6,7,8]]
+        = (4, 2): i32);
+    matrix_transitive!(ColumnMatrix4x3 Vector4[
+        x=[1,2,3,4],
+        y=[5,6,7,8],
+        z=[9,10,11,12]]
+        = (4, 3): i32);
     matrix_transitive!(ColumnMatrix4 Vector4[
         x=[1,2,3,4],
         y=[5,6,7,8],
@@ -144,6 +184,14 @@ fn turn() {
         [1,2],
         [3,4],
         [5,6]]);
+    turn!(RowMatrix2x4 [
+        [1,3,5,7],
+        [2,4,6,8]]
+        = ColumnMatrix2x4 [
+        [1,2],
+        [3,4],
+        [5,6],
+        [7,8]]);
     turn!(RowMatrix3x2 [
         [1,2],
         [3,4],
@@ -168,6 +216,14 @@ fn turn() {
         [4,5,6],
         [7,8,9],
         [10,11,12]]);
+    turn!(RowMatrix4x2 [
+        [1,2],
+        [3,4],
+        [5,6],
+        [7,8]]
+        = ColumnMatrix4x2 [
+        [1,3,5,7],
+        [2,4,6,8]]);
     turn!(RowMatrix4x3 [
         [1,2,3],
         [4,5,6],


### PR DESCRIPTION
I have no idea if there's any practical use for these, but OpenGL, `nalgebra`, and probably other math crates expose them and they fit within the `2x2-4x4` matrix range exposed by this crate, so I can't see a reason not to have them.