### PR TITLE
Trait for more concise conversions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,13 @@ mod vector;
 pub use matrix::*;
 pub use rotation::*;
 pub use vector::*;
+
+/// Conversion directly between types that implement `From` for the same `mint` type.
+pub trait Convert: Sized {
+    /// The corresponding `mint` type
+    type Via: From<Self>;
+    /// Convert into an equivalent type
+    fn convert<T: From<Self::Via>>(self) -> T {
+        T::from(Self::Via::from(self))
+    }
+}


### PR DESCRIPTION
If math libraries implement this trait, it will allow conversions between two different libraries' types, which would previously have always been written `mint::Foo::from(x).into()`, to be written as `x.convert()` when types are unambiguous. This makes `mint` more ergonomic when dealing with downstream crates written against a specific math library. Bikeshedding welcome.