### PR TITLE
Make mint no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ Mint - Math interoperability standard types.
 Defines basic math types useful for computer graphics.
 Designed to serve as an interoperability standard between libraries.
 */
+#![no_std]
 #![deny(missing_docs)]
 
 mod matrix;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,5 +1,4 @@
 use vector::{Vector2, Vector3, Vector4};
-use std::mem;
 
 macro_rules! matrix {
     ($name:ident : $vec:ident[ $($field:ident[$($sub:ident),*] = $index:expr),* ] = ($inner:expr, $outer:expr)) => {
@@ -27,7 +26,7 @@ macro_rules! matrix {
         }
 
         impl<T> AsRef<[[T; $inner]; $outer]> for $name<T> {
-            fn as_ref(&self) -> &[[T; $inner]; $outer] { unsafe { mem::transmute(self) } }
+            fn as_ref(&self) -> &[[T; $inner]; $outer] { unsafe { ::core::mem::transmute(self) } }
         }
 
         impl<T: Clone> From<[T; $inner * $outer]> for $name<T> {
@@ -50,7 +49,7 @@ macro_rules! matrix {
         }
 
         impl<T> AsRef<[T; $inner * $outer]> for $name<T> {
-            fn as_ref(&self) -> &[T; $inner * $outer] { unsafe { mem::transmute(self) } }
+            fn as_ref(&self) -> &[T; $inner * $outer] { unsafe { ::core::mem::transmute(self) } }
         }
     };
 }

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 use vector::Vector3;
 
 
@@ -30,7 +30,7 @@ impl<T> Into<[T; 4]> for Quaternion<T> {
 }
 
 impl<T> AsRef<[T; 4]> for Quaternion<T> {
-    fn as_ref(&self) -> &[T; 4] { unsafe { ::std::mem::transmute(self) } }
+    fn as_ref(&self) -> &[T; 4] { unsafe { ::core::mem::transmute(self) } }
 }
 
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -24,7 +24,7 @@ macro_rules! vec {
         }
 
         impl<T> AsRef<$fixed> for $name<T> {
-            fn as_ref(&self) -> &$fixed { unsafe { ::std::mem::transmute(self) } }
+            fn as_ref(&self) -> &$fixed { unsafe { ::core::mem::transmute(self) } }
         }
 
         impl<T: Clone> $name<T> {


### PR DESCRIPTION
This will allow the library to be built for `no_std` targets such as embedded microcontrollers that could benefit from this library.