### PR TITLE
Fix Quaternion memory layout

### DIFF
--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -8,10 +8,10 @@ use vector::Vector3;
 #[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(C)]
 pub struct Quaternion<T> {
-    /// Scalar part of a quaternion.
-    pub s: T,
     /// Vector part of a quaternion.
     pub v: Vector3<T>,
+    /// Scalar part of a quaternion.
+    pub s: T,
 }
 
 impl<T> From<[T; 4]> for Quaternion<T> {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -256,3 +256,21 @@ fn vector_from_slice_success() {
 fn vector_from_slice_fail() {
     let _ = Vector4::from_slice(&[0.0]);
 }
+
+#[test]
+fn quaternion_layout() {
+    let q = Quaternion {
+        v: Vector3::from([0, 1, 2]),
+        s: 3,
+    };
+    let expected = [0, 1, 2, 3];
+
+    let a: [i32; 4] = q.into();
+    assert_eq!(a, expected);
+
+    let b: &[i32; 4] = q.as_ref();
+    assert_eq!(b, &expected);
+
+    let c: [i32; 4] = unsafe { core::mem::transmute(q) };
+    assert_eq!(c, expected);
+}


### PR DESCRIPTION
The Quaternion memory layout is now `[x, y, z, w]` (i.e. scalar at the end). This is consistent with the `Into` trait implementation and also consistent with other libraries (such as GLM) and the GLTF spec.

Fixes #49