### PR TITLE
Add optional support for `bytemuck`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ documentation = "https://docs.rs/mint"
 keywords = ["math"]
 
 [dependencies]
+bytemuck = { version = "1.2", optional = true }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -9,6 +9,11 @@ macro_rules! matrix {
             $( pub $field : $vec<T>, )*
         }
 
+        #[cfg(feature = "bytemuck")]
+        unsafe impl<T> bytemuck::Zeroable for $name<T> {}
+        #[cfg(feature = "bytemuck")]
+        unsafe impl<T: Copy + 'static> bytemuck::Pod for $name<T> {}
+
         impl<T> From<[[T; $inner]; $outer]> for $name<T> {
             fn from([$($field),*]: [[T; $inner]; $outer]) -> Self {
                 $name {

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -14,6 +14,11 @@ pub struct Quaternion<T> {
     pub s: T,
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> bytemuck::Zeroable for Quaternion<T> {}
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Copy + 'static> bytemuck::Pod for Quaternion<T> {}
+
 impl<T> From<[T; 4]> for Quaternion<T> {
     fn from([x, y, z, s]: [T; 4]) -> Self {
         Quaternion {
@@ -73,6 +78,11 @@ pub enum ExtraZXZ {}
 /// Extrinsic rotation around Z, then Y, then X axis.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
 pub enum ExtraZYX {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T, B> bytemuck::Zeroable for EulerAngles<T, B> {}
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Copy + 'static, B: Copy + 'static> bytemuck::Pod for EulerAngles<T, B> {}
 
 impl<T, B> From<[T; 3]> for EulerAngles<T, B> {
     fn from([a, b, c]: [T; 3]) -> Self {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -7,6 +7,11 @@ macro_rules! vec {
             $( pub $field : T, )*
         }
 
+        #[cfg(feature = "bytemuck")]
+        unsafe impl<T> bytemuck::Zeroable for $name<T> {}
+        #[cfg(feature = "bytemuck")]
+        unsafe impl<T: Copy + 'static> bytemuck::Pod for $name<T> {}
+
         impl<T> From<$fixed> for $name<T> {
             fn from([$($field),*]: $fixed) -> Self {
                 $name {


### PR DESCRIPTION
[`bytemuck`](https://github.com/Lokathor/bytemuck) is a crate that allows simple casts between "plain old data" types. With this pull request, the following becomes possible:

```rust
use mint::Vector2;

fn main() {
    let data = &[
        Vector2::<u16>::from([1, 1]),
        Vector2::<u16>::from([1, 0]),
        Vector2::<u16>::from([0, 0]),
        Vector2::<u16>::from([0, 1]),
    ];
    let raw_data: &[u8] = bytemuck::cast_slice(data);
    assert_eq!(
        raw_data,
        &[
            1, 0, 1, 0,
            1, 0, 0, 0,
            0, 0, 0, 0,
            0, 0, 1, 0,
        ]
    );
}
```