### PR TITLE
Reprise of #20: serde support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: rust
 rust:
   - stable
 script:
-  - cargo test --all
+  - cargo test --features serde --all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.5.6 (tbd)
+- add serde support
+
 ## v0.5.5 (13-04-2020)
 - fixed the `Quaternion` memory layout
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ documentation = "https://docs.rs/mint"
 keywords = ["math"]
 
 [dependencies]
+serde = { version = "1.0", optional = true, default-features = false }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 This library provides standard mathematical types used in computer graphics.
 Its only purpose is to serve as a standard and interoperability language between various components of [rust-gamedev](http://arewegameyet.com/categories/math/) ecosystem that happen to expose math-related types on their API.
-There are no operations defined for the types other than for the means of conversion from/into external types.
+There are no operations defined for the types other than for the means of conversion from/into external types.  
+Serde support is available through the `serde` feature.
 
 ## Types
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ Designed to serve as an interoperability standard between libraries.
 #![no_std]
 #![deny(missing_docs)]
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
 mod matrix;
 mod rotation;
 mod vector;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -51,6 +51,28 @@ macro_rules! matrix {
         impl<T> AsRef<[T; $inner * $outer]> for $name<T> {
             fn as_ref(&self) -> &[T; $inner * $outer] { unsafe { ::core::mem::transmute(self) } }
         }
+
+        #[cfg(feature = "serde")]
+        impl<T> ::serde::Serialize for $name<T>
+            where T: ::serde::Serialize
+        {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where S: ::serde::Serializer
+            {
+                AsRef::<[[T; $inner]; $outer]>::as_ref(self).serialize(serializer)
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de, T> ::serde::Deserialize<'de> for $name<T>
+            where T: ::serde::Deserialize<'de>
+        {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where D: ::serde::Deserializer<'de>
+            {
+                <[[T; $inner]; $outer]>::deserialize(deserializer).map($name::<T>::from)
+            }
+        }
     };
 }
 

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -1,7 +1,6 @@
 use core::marker::PhantomData;
 use vector::Vector3;
 
-
 /// Standard quaternion represented by the scalar and vector parts.
 /// Useful for representing rotation in 3D space.
 /// Corresponds to a right-handed rotation matrix.
@@ -30,9 +29,32 @@ impl<T> Into<[T; 4]> for Quaternion<T> {
 }
 
 impl<T> AsRef<[T; 4]> for Quaternion<T> {
-    fn as_ref(&self) -> &[T; 4] { unsafe { ::core::mem::transmute(self) } }
+    fn as_ref(&self) -> &[T; 4] {
+        unsafe { ::core::mem::transmute(self) }
+    }
 }
 
+#[cfg(feature = "serde")]
+impl<T> ::serde::Serialize for Quaternion<T>
+    where T: ::serde::Serialize
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: ::serde::Serializer
+    {
+        AsRef::<[T; 4]>::as_ref(self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T> ::serde::Deserialize<'de> for Quaternion<T>
+    where T: ::serde::Deserialize<'de>
+{
+    fn deserialize<S>(deserializer: S) -> Result<Self, S::Error>
+        where S: ::serde::Deserializer<'de>
+    {
+        <[T; 4]>::deserialize(deserializer).map(Quaternion::<T>::from)
+    }
+}
 
 /// Abstract set of Euler angles in 3D space. The basis of angles
 /// is defined by the generic parameter `B`.
@@ -88,6 +110,32 @@ impl<T, B> From<[T; 3]> for EulerAngles<T, B> {
 impl<T, B> Into<[T; 3]> for EulerAngles<T, B> {
     fn into(self) -> [T; 3] {
         [self.a, self.b, self.c]
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, B> ::serde::Serialize for EulerAngles<T, B>
+where
+    T: ::serde::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        [&self.a, &self.b, &self.c].serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, B> ::serde::Deserialize<'de> for EulerAngles<T, B>
+where
+    T: ::serde::Deserialize<'de>,
+{
+    fn deserialize<S>(deserializer: S) -> Result<Self, S::Error>
+    where
+        S: ::serde::Deserializer<'de>,
+    {
+        <[T; 3]>::deserialize(deserializer).map(EulerAngles::<T, B>::from)
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -41,6 +41,28 @@ macro_rules! vec {
                 }
             }
         }
+
+        #[cfg(feature = "serde")]
+        impl<T> ::serde::Serialize for $name<T>
+            where T: ::serde::Serialize
+        {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where S: ::serde::Serializer
+            {
+                AsRef::<$fixed>::as_ref(self).serialize(serializer)
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de, T> ::serde::Deserialize<'de> for $name<T>
+            where T: ::serde::Deserialize<'de>,
+        {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where D: ::serde::Deserializer<'de>
+            {
+                <$fixed>::deserialize(deserializer).map($name::<T>::from)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Adds serde support through a serde feature. I do not know why the author's old PR was closed since it all seems to work perfectly. Only changed std:: to core:: to support no-std and other small things like readme update and travis serde test.  

Fixes #41 