### PR TITLE
Implement AsMut<array>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
-### v0.5.8
+### v0.5.9 (XX-XX-2022)
+- implement `AsMut<array>`
+
+### v0.5.8 (22-10-2021)
 - add `IntoMint` trait for unique conversions ([#68])
 
 [#68]: https://github.com/kvark/mint/pull/68

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mint"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2018"
 authors = [
 	"Benjamin Saunders <ben.e.saunders@gmail.com>",

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -34,6 +34,10 @@ macro_rules! matrix {
             fn as_ref(&self) -> &[[T; $inner]; $outer] { unsafe { ::core::mem::transmute(self) } }
         }
 
+        impl<T> AsMut<[[T; $inner]; $outer]> for $name<T> {
+            fn as_mut(&mut self) -> &mut [[T; $inner]; $outer] { unsafe { ::core::mem::transmute(self) } }
+        }
+
         impl<T: Clone> From<[T; $inner * $outer]> for $name<T> {
             fn from(m: [T; $inner * $outer]) -> Self {
                 $name {
@@ -55,6 +59,10 @@ macro_rules! matrix {
 
         impl<T> AsRef<[T; $inner * $outer]> for $name<T> {
             fn as_ref(&self) -> &[T; $inner * $outer] { unsafe { ::core::mem::transmute(self) } }
+        }
+
+        impl<T> AsMut<[T; $inner * $outer]> for $name<T> {
+            fn as_mut(&mut self) -> &mut [T; $inner * $outer] { unsafe { ::core::mem::transmute(self) } }
         }
 
         #[cfg(feature = "serde")]

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -39,6 +39,12 @@ impl<T> AsRef<[T; 4]> for Quaternion<T> {
     }
 }
 
+impl<T> AsMut<[T; 4]> for Quaternion<T> {
+    fn as_mut(&mut self) -> &mut [T; 4] {
+        unsafe { ::core::mem::transmute(self) }
+    }
+}
+
 #[cfg(feature = "serde")]
 impl<T> ::serde::Serialize for Quaternion<T>
 where

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -33,6 +33,10 @@ macro_rules! vec {
             fn as_ref(&self) -> &$fixed { unsafe { ::core::mem::transmute(self) } }
         }
 
+        impl<T> AsMut<$fixed> for $name<T> {
+            fn as_mut(&mut self) -> &mut $fixed { unsafe { ::core::mem::transmute(self) } }
+        }
+
         impl<T: Clone> $name<T> {
             #[allow(missing_docs)]
             pub fn from_slice(slice: &[T]) -> Self {


### PR DESCRIPTION
I'm working on a library that will make it easy to lay out different types into a buffer according to WGSL's memory layout (akin to [crevice](https://github.com/LPGhatguy/crevice)) and adding support for types that can become mutable arrays would allow me to read back the data in a more generic fashion since most matrix/math crates already implement `AsMut<array>`.

This is more or less a copy paste of the existing code used for `AsRef<array>`.