### PR TITLE
Implement Default, bump version to 0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
-### v0.5.9 (XX-XX-2022)
+### v0.5.10 (01-01-2024)
+- implement `Default`
+
+### v0.5.9 (02-02-2022)
 - implement `AsMut<array>`
 
 ### v0.5.8 (22-10-2021)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mint"
-version = "0.5.9"
+version = "0.5.10"
+#TODO: update to 2021 when MSRV allows
 edition = "2018"
 authors = [
 	"Benjamin Saunders <ben.e.saunders@gmail.com>",
@@ -22,4 +23,4 @@ keywords = ["math"]
 serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = "=1.0.100" # later versions use rust-2021

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@ Designed to serve as an interoperability standard between libraries.
 #![no_std]
 #![deny(
     missing_docs,
-    rust_2018_compatibility,
-    rust_2018_idioms,
     future_incompatible,
     nonstandard_style,
     unused,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -3,7 +3,7 @@ use crate::IntoMint;
 
 macro_rules! matrix {
     ($name:ident : $vec:ident[ $($field:ident[$($sub:ident),*] = $index:expr),* ] = ($inner:expr, $outer:expr)) => {
-        #[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
+        #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord)]
         #[repr(C)]
         #[allow(missing_docs)] //TODO: actually have docs
         pub struct $name<T> {

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 /// Standard quaternion represented by the scalar and vector parts.
 /// Useful for representing rotation in 3D space.
 /// Corresponds to a right-handed rotation matrix.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(C)]
 pub struct Quaternion<T> {
     /// Vector part of a quaternion.
@@ -110,6 +110,17 @@ pub enum ExtraZXZ {}
 /// Extrinsic rotation around Z, then Y, then X axis.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
 pub enum ExtraZYX {}
+
+impl<T: Default, B> Default for EulerAngles<T, B> {
+    fn default() -> Self {
+        Self {
+            a: T::default(),
+            b: T::default(),
+            c: T::default(),
+            marker: PhantomData,
+        }
+    }
+}
 
 impl<T, B> From<[T; 3]> for EulerAngles<T, B> {
     fn from([a, b, c]: [T; 3]) -> Self {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -2,7 +2,7 @@ use crate::IntoMint;
 
 macro_rules! vec {
     ($name:ident [ $($field:ident),* ] = $fixed:ty) => {
-        #[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
+        #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord)]
         #[repr(C)]
         #[allow(missing_docs)] //TODO: actually have docs
         pub struct $name<T> {


### PR DESCRIPTION
Closes #58
cc @jgarvin @Ralith 

Based on the discussion, I'd like to have Qaternions and Matrices default to "identity" but unfortunately we don't have any type constraints in here, so I don't have access to `One` for identity construction. Therefore, this PR just defaults to all zeroes.